### PR TITLE
fix: timeout semantic-release step after 1 hour

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,3 +55,4 @@ runs:
         CFA_PROJECT_ID: ${{ inputs.project-id }}
         CFA_SECRET: ${{ inputs.secret }}
         NPM_TOKEN: ${{ inputs.npm-token }}
+      timeout-minutes: 60


### PR DESCRIPTION
The GH token acquired and passed to the `semantic-release` step is only good for 1 hour, and if a maintainer provides a CFA token after that time we end up with the npm publish going through but none of the follow-up steps on GitHub (creating the release, commenting on PRs, etc). So let's timeout this step after 1 hour to prevent this edge case.