### PR TITLE
fix: revert usage of timeout-minutes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,4 +55,3 @@ runs:
         CFA_PROJECT_ID: ${{ inputs.project-id }}
         CFA_SECRET: ${{ inputs.secret }}
         NPM_TOKEN: ${{ inputs.npm-token }}
-      timeout-minutes: 60


### PR DESCRIPTION
Reverts #7. It turns out (for some reason), `timeout-minutes` is not valid inside an action (verified with [this schema](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-action.json) and [the docs](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#runs-for-composite-actions)), so this is causing a syntax error when trying to run. I'll just put the `timeout-minutes: 60` line in the release workflows themselves.